### PR TITLE
Fixes loader when querying folders in dynamic folder mode

### DIFF
--- a/astro-cloudinary/src/lib/resources.ts
+++ b/astro-cloudinary/src/lib/resources.ts
@@ -101,7 +101,6 @@ export async function listResources(options: ListResourcesOptions): Promise<List
       params.append('asset_folder', options.folder);
 
       response = await cldRequest(`/resources/by_asset_folder?${params}`);
-
     } else if ( options.folderMode === 'fixed' ) {
       
       params.append('prefix', options.folder);
@@ -116,7 +115,7 @@ export async function listResources(options: ListResourcesOptions): Promise<List
   }
 
   if ( !response.ok ) {
-    throw new Error('Failed to list resources.');
+    throw new Error(`Failed to list resources - ${response.statusText}`);
   }
 
   const data = await response.json();

--- a/astro-cloudinary/src/lib/resources.ts
+++ b/astro-cloudinary/src/lib/resources.ts
@@ -96,13 +96,13 @@ export async function listResources(options: ListResourcesOptions): Promise<List
 
   if ( options.folder ) {
     if ( options.folderMode === 'dynamic' ) {
-      
-      // @TODO Test with dynamic folder mode
+
       params.append('asset_folder', options.folder);
 
       response = await cldRequest(`/resources/by_asset_folder?${params}`);
+
     } else if ( options.folderMode === 'fixed' ) {
-      
+
       params.append('prefix', options.folder);
 
       response = await cldRequest(`/resources/${options.resourceType}?${params}`);

--- a/astro-cloudinary/src/lib/resources.ts
+++ b/astro-cloudinary/src/lib/resources.ts
@@ -100,7 +100,7 @@ export async function listResources(options: ListResourcesOptions): Promise<List
       // @TODO Test with dynamic folder mode
       params.append('asset_folder', options.folder);
 
-      response = await cldRequest(`/by_asset_folder?${params}`);
+      response = await cldRequest(`/resources/by_asset_folder?${params}`);
 
     } else if ( options.folderMode === 'fixed' ) {
       

--- a/docs/src/components/DemoAssetsLoaderSamplesSingle.astro
+++ b/docs/src/components/DemoAssetsLoaderSamplesSingle.astro
@@ -5,12 +5,13 @@ import { CldImage } from '../../../astro-cloudinary';
 
 const asset = await getEntry('assetsSamplesLimit', 'collection/a7ruc9xysr0lkxip4cgg');
 ---
-
-<CldImage
-  class="block"
-  src={asset.data.public_id}
-  width={900}
-  height={900}
-  crop="lfill"
-  alt=""
-/>
+{asset && (
+  <CldImage
+    class="block"
+    src={asset.data.public_id}
+    width={900}
+    height={900}
+    crop="lfill"
+    alt=""
+  />
+)}


### PR DESCRIPTION
# Description

When in dynamic folder mode, the assets loader needs to make a different request than the classic fixed folder mode. The path to the resources endpoint was incorrect, leading to failed requests.

This simply updates the endpoint to properly request the assets.

## Issue Ticket Number

Fixes #26 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/astro-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [X] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [X] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [X] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [X] I have performed a self-review of my own code
- [X] I have run tests locally to ensure they all pass
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes needed to the documentation
