### PR TITLE
remove duplicate item from side bar

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -178,10 +178,6 @@ export default defineConfig({
               slug: 'guides/responsive-images'
             },
             {
-              label: 'Responsive Images',
-              slug: 'guides/responsive-images'
-            },
-            {
               label: 'Social Media Card',
               slug: 'guides/social-media-card'
             },


### PR DESCRIPTION
# Description

Responsive Images are displayed multiple times in the sidebar of docs. This PR fixes it. 
![Screenshot 2024-10-03 at 9 13 00 PM](https://github.com/user-attachments/assets/d87e526a-2d34-4495-a4f3-ac2569be95bc)

## Issue Ticket Number

Fixes #38 


## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
