### PR TITLE
Fix broken links in basic-usage.mdx

### DIFF
--- a/docs/src/content/docs/getcldimageurl/basic-usage.mdx
+++ b/docs/src/content/docs/getcldimageurl/basic-usage.mdx
@@ -165,5 +165,5 @@ https://res.cloudinary.com/<Cloud Name>/image/upload/e_background_removal/b_blue
 
 ## Learn More about getCldImageUrl
 
-* [Configuration](/cldimageurl/configuration)
-* [Examples](/cldimageurl/examples)
+* [Configuration](/getcldimageurl/configuration)
+* [Examples](/getcldimageurl/examples)


### PR DESCRIPTION
# Description
Fix broken links on: https://astro.cloudinary.dev/getcldimageurl/basic-usage

Links to further docs on Configuration, and Examples are broken at the foot of the page and lead to a blank page.

## Issue Ticket Number

Fixes #67

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/astro-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

- [ x] Fix or improve the documentation

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
