### PR TITLE
Add Astro 5 as peer dependency

### DIFF
--- a/astro-cloudinary/package.json
+++ b/astro-cloudinary/package.json
@@ -47,7 +47,7 @@
     "unpic": "^3.18.0"
   },
   "peerDependencies": {
-    "astro": "^3.2.0 || ^4.0.0"
+    "astro": "^3.2.0 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "astro": "^4.15.6"


### PR DESCRIPTION
# Description

Adds Astro `^5.0.0` as a peer dependency to avoid peer dependency conflicts when using this with Astro 5.

## Issue Ticket Number

Fixes #68 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] ~I~ (others) have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] ~I have commented my code, particularly in hard-to-understand areas~ - N/A
- [ ] ~I have made corresponding changes needed to the documentation~ - N/A

_I'm not sure if the failing tests in #75 mean there's more work to do to support using `astro-cloudinary` with Astro 5, but based on the anecdotal reports that [it seems to work fine](https://github.com/cloudinary-community/astro-cloudinary/issues/68#issuecomment-2553995837), I've opened this to get the ball rolling on removing the npm installation error. 🎳_ 