### PR TITLE
fix(CldVideoPlayer): add event listener to 'astro:page-load' instead of 'load' to ensure Client Router / View Transitions compatibility

### DIFF
--- a/astro-cloudinary/src/components/CldVideoPlayer.astro
+++ b/astro-cloudinary/src/components/CldVideoPlayer.astro
@@ -81,7 +81,7 @@ interface Cloudinary {
   videoPlayer: (video: HTMLVideoElement, options: {}) => CloudinaryVideoPlayer;
 }
 
-window.addEventListener('load', async () => {
+window.addEventListener('astro:page-load', async () => {
   const videos = document.querySelectorAll('.astro-cloudinary-cldvideoplayer') as NodeListOf<HTMLVideoElement>;
 
   if ( videos.length === 0 ) return;


### PR DESCRIPTION
# Description

This PR adjusts the `CldVideoPlayer` to add an event listener to [`astro:page-load`](https://docs.astro.build/en/guides/view-transitions/#astropage-load) instead of `load` to ensure the video player is also initialized when navigating to a page via the `ClientRouter` ([View Transitions](https://docs.astro.build/en/guides/view-transitions)).

## Issue Ticket Number

Fixes #90

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
