### PR TITLE
fix(docs): enable HTML syntax highlighting in Responsive Images guide (#119)

### DIFF
--- a/docs/src/content/docs/guides/responsive-images.mdx
+++ b/docs/src/content/docs/guides/responsive-images.mdx
@@ -58,9 +58,10 @@ tablets, and 3-column layout on desktop views.
 The difference with the CldImage component is that it utilizes Cloudinary tech
 in order to provide the responsive sizing.
 
+
 In the example above, the output would look like:
 
-```
+```html
 <img
   class="astro-cloudinary-cldimage"
   sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
@@ -133,7 +134,8 @@ Each image will be cropped to a 1:1 ratio represented by the width and height pr
 As the underlaying Unpic Image component generates an image for each responsive size,
 Cloudinary will use those sizes when building the URL, for example:
 
-```
+
+```html
 <img
   alt="Turtle"
   loading="lazy"
@@ -195,7 +197,8 @@ than a 640x640 image.
 
 The resulting transformations may look like:
 
-```
+
+```text
 .../w_256,h_256,c_thumb/...
 .../w_384,h_384,c_thumb/...
 .../w_640,h_640,c_thumb/...
@@ -254,7 +257,8 @@ values by explicitly setting them.
 
 The resulting transformations may look like:
 
-```
+
+```text
 .../w_960,h_960,c_thumb/<Other Transformations>/w_256,h_256,c_limit/...
 .../w_960,h_960,c_thumb/<Other Transformations>/w_384,h_384,c_limit/...
 .../w_960,h_960,c_thumb/<Other Transformations>/w_640,h_640,c_limit/...


### PR DESCRIPTION
This PR fixes #119 by ensuring HTML code blocks in the Responsive Images guide use the correct language tag for syntax highlighting. Now, both JSX and HTML examples are properly highlighted in the docs.
