### PR TITLE
Clean up CldVideoPlayer and CldUploadWidget on astro:before-swap

### DIFF
--- a/astro-cloudinary/src/components/CldUploadWidget.astro
+++ b/astro-cloudinary/src/components/CldUploadWidget.astro
@@ -53,7 +53,7 @@ interface Cloudinary {
   createUploadWidget: CloudinaryCreateUploadWidget;
 }
 
-window.addEventListener('load', async () => {
+async function initCldUploadWidgets() {
   const widgets = document.querySelectorAll('.astro-cloudinary-clduploadwidget') as NodeListOf<HTMLSpanElement>;
 
   if ( widgets.length === 0 ) return;
@@ -76,7 +76,7 @@ window.addEventListener('load', async () => {
   const cloudinary = window.cloudinary as Cloudinary;
 
   widgets.forEach(widget => {
-    let widgetInstance: CloudinaryUploadWidget;
+    let widgetInstance: CloudinaryUploadWidget | undefined;
 
     // Primary user interaction point for the upload widget, create
     // an instance if it doesnt already exist (someone triggering before idle)
@@ -97,6 +97,15 @@ window.addEventListener('load', async () => {
       }
       widgetInstance.open();
     });
+
+    // Cleanup
+    document.addEventListener('astro:before-swap', async () => {
+      if (widgetInstance) {
+        widgetInstance.destroy().finally(() => {
+          widgetInstance = undefined;
+        });
+      }
+    }, { once: true });
 
     // Parse the upload options from the DOM and configure the
     // remaining options that couldn't be serialized
@@ -155,5 +164,39 @@ window.addEventListener('load', async () => {
       }, resultsCallback);
     }
   });
-})
+}
+
+function useState() {
+  let isInitialising = false;
+  let isInitialised = false;
+
+  return {
+    async initialise() {
+      if (!isInitialising && !isInitialised) {
+        isInitialising = true;
+        await initCldUploadWidgets()
+          .then(() => {
+            isInitialised = true;
+          })
+          .finally(() => {
+            isInitialising = false;
+          });
+      }
+    },
+
+    reset() {
+      isInitialising = false;
+      isInitialised = false;
+    },
+  };
+}
+
+const state = useState();
+
+window.addEventListener('load', state.initialise);
+
+// Lifecycle events, requires <ClientRouter />
+// https://docs.astro.build/en/guides/view-transitions/#lifecycle-events
+document.addEventListener('astro:after-swap', state.reset);
+document.addEventListener('astro:page-load', state.initialise);
 </script>

--- a/astro-cloudinary/src/components/CldVideoPlayer.astro
+++ b/astro-cloudinary/src/components/CldVideoPlayer.astro
@@ -81,7 +81,7 @@ interface Cloudinary {
   videoPlayer: (video: HTMLVideoElement, options: {}) => CloudinaryVideoPlayer;
 }
 
-window.addEventListener('load', async () => {
+async function initCldVideoPlayers() {
   const videos = document.querySelectorAll('.astro-cloudinary-cldvideoplayer') as NodeListOf<HTMLVideoElement>;
 
   if ( videos.length === 0 ) return;
@@ -120,8 +120,13 @@ window.addEventListener('load', async () => {
 
     if ( !player ) return;
 
-    // Loop through all avialable player events and create custom event callbacks
+    // Cleanup
+    document.addEventListener('astro:before-swap', async () => {
+      player.dispose();
+      player.videojs.cloudinary.dispose();
+    }, { once: true });
 
+    // Loop through all avialable player events and create custom event callbacks
     const events = [
       'loadstart',
       'suspend',
@@ -169,5 +174,39 @@ window.addEventListener('load', async () => {
       });
     });
   })
-});
+}
+
+function useState() {
+  let isInitialising = false;
+  let isInitialised = false;
+
+  return {
+    async initialise() {
+      if (!isInitialising && !isInitialised) {
+        isInitialising = true;
+        await initCldVideoPlayers()
+          .then(() => {
+            isInitialised = true;
+          })
+          .finally(() => {
+            isInitialising = false;
+          });
+      }
+    },
+
+    reset() {
+      isInitialising = false;
+      isInitialised = false;
+    },
+  };
+}
+
+const state = useState()
+
+window.addEventListener('load', state.initialise);
+
+// Lifecycle events, requires <ClientRouter />
+// https://docs.astro.build/en/guides/view-transitions/#lifecycle-events
+document.addEventListener('astro:after-swap', state.reset);
+document.addEventListener('astro:page-load', state.initialise);
 </script>


### PR DESCRIPTION
# Description

This PR adds cleanup handling for the `<CldUploadWidget />` and `<CldVideoPlayer />` components on the `astro:before-swap` event.

Reference: https://cloudinary.com/documentation/upload_widget_reference#destroy
Reference: https://cloudinary.com/documentation/video_player_api_reference#dispose
Reference: https://docs.astro.build/en/guides/view-transitions/#astrobefore-swap

I created 3 minimal files locally to verify the changes:

```astro
<!-- docs/src/pages/TestLayout.astro -->
---
import { ClientRouter } from "astro:transitions";
const { title } = Astro.props;
---
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <ClientRouter/>
  </head>
  <body>
    <nav>
      <a href="/upload">CldUploadWidget</a>
      <a href="/video">CldVideoPlayer</a>
    </nav>
    <h1>{title}</h1>
    <article>
      <slot /> <!-- your content is injected here -->
    </article>
  </body>
</html>
```

```astro
<!-- docs/src/pages/upload.astro -->
---
import { CldUploadWidget } from "../../../astro-cloudinary";
import TestLayout from "./TestLayout.astro";
---

<TestLayout title="Cleanup CldUploadWidget">
  <CldUploadWidget uploadPreset="astro-cloudinary-signed" signatureEndpoint="/api/sign-cloudinary-params">
    <button>Upload</button>
  </CldUploadWidget>

  <CldUploadWidget options={{ sources: ['local', 'url', 'unsplash'] }} uploadPreset="astro-cloudinary-unsigned">
    <button>Upload</button>
  </CldUploadWidget>
</TestLayout>
```

```astro
<!-- docs/src/pages/video.astro -->
---
import { CldVideoPlayer } from "../../../astro-cloudinary";
import TestLayout from "./TestLayout.astro";
---

<TestLayout title="Cleanup CldVideoPlayer">
  <CldVideoPlayer src="samples/sea-turtle" width="1920" height="1080" />
  <CldVideoPlayer src="samples/elephants" width="1920" height="1080" />
</TestLayout>
```

Here is a screen recording of the testing performed with debugging `console.log` statements:

https://github.com/user-attachments/assets/37cf2f40-aa51-4935-9240-efeea311f8e7


## Issue Ticket Number

Closes https://github.com/cloudinary-community/astro-cloudinary/issues/10.

This commit also fixes https://github.com/cloudinary-community/astro-cloudinary/issues/90.

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
