### PR TITLE
Fix video error due to unsupported 'auto' streaming profile

### DIFF
--- a/astro-cloudinary/src/components/CldVideoPlayer.astro
+++ b/astro-cloudinary/src/components/CldVideoPlayer.astro
@@ -38,6 +38,19 @@ const cloudinaryConfig = getCloudinaryConfig(config);
 const playerOptions = getVideoPlayerOptions(props, cloudinaryConfig);
 const { publicId } = playerOptions;
 
+if (playerOptions.transformation && Array.isArray(playerOptions.transformation)) {
+  const hasStreamingProfileAuto = playerOptions.transformation.some(
+    (transform: any) => transform.streaming_profile === 'auto'
+  );
+
+  if (hasStreamingProfileAuto) {
+    // Remove any quality parameter from transformations when streaming_profile is 'auto'
+    playerOptions.transformation = playerOptions.transformation.filter(
+      (transform: any) => !('quality' in transform)
+    );
+  }
+}
+
 if ( typeof publicId === 'undefined' ) {
   throw new Error('[CldVideoPlayer] Public ID or Cloudinary URL required - please specify a src prop.');
 }


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->

Fixes an error with `CldVideoPlayer` described in the attached issue. This detects when `streaming_profile: 'auto'` is used and removes the conflicting `quality` parameter.

(This is only one possible solution and ideas for an alternate fix are welcome!)

Here's a demo page which replicates the error with the latest version of the SDK, but works with my change applied:

```
---
import { CldVideoPlayer } from 'astro-cloudinary';
---

<html lang="en">
	<head>
		<meta charset="utf-8" />
		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
		<meta name="viewport" content="width=device-width" />
		<meta name="generator" content={Astro.generator} />
		<title>Astro Cloudinary Test - Issue #32</title>
	</head>
	<body>
		<main>
			<h1>Testing CldVideoPlayer with streaming_profile: 'auto'</h1>

			<div style="margin: 20px 0;">
				<h2>This should work (streaming_profile: 'hd'):</h2>
				<CldVideoPlayer
					src="samples/sea-turtle"
					width="1920"
					height="1080"
					sourceTypes={['hls']}
					transformation={{
						streaming_profile: 'hd',
					}}
				/>
			</div>

			<div style="margin: 20px 0;">
				<h2>This should fail (streaming_profile: 'auto'):</h2>
				<CldVideoPlayer
					src="samples/sea-turtle"
					width="1920"
					height="1080"
					sourceTypes={['hls']}
					transformation={{
						streaming_profile: 'auto',
					}}
				/>
			</div>
		</main>
	</body>
</html>
```

## Issue Ticket Number

Fixes #32

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/astro-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/astro-cloudinary/issues) ticket for this PR - _I fixed an existing issue instead!_
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/astro-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass - _or rather manually tested the bugfix_
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation - _it's a bugfix so this is not needed_